### PR TITLE
Fix cors thing

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -13,9 +13,14 @@ app = FastAPI(
     openapi_url=Settings["api_prefix"],
 )
 
+origins = [
+    "http://localhost:5501",
+    "http://localhost:63342",
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Changes Made
### Fixes
- The server blocking requests from frontend

### API Changes


## Misc

Port `5501` serves as the default for VSCode Live Server, while `63342` is the standard port for PyCharm.